### PR TITLE
Add dump_to_embedded/2 to fix JSON serialization for AshPaperTrail (and maybe others)

### DIFF
--- a/lib/type.ex
+++ b/lib/type.ex
@@ -64,6 +64,24 @@ defmodule AshUlid.Type do
   def dump_to_native(nil, _), do: {:ok, nil}
   def dump_to_native(_, _), do: :error
 
+  @impl true
+  def dump_to_embedded(nil, _), do: {:ok, nil}
+
+  def dump_to_embedded(value, _constraints) when is_binary(value) do
+    # If it's already a string ULID (26 chars), return as-is
+    if String.length(value) == 26 do
+      {:ok, value}
+    else
+      # If it's a binary UUID (16 bytes), convert to ULID string
+      case cast_stored(value, []) do
+        {:ok, ulid_string} -> {:ok, ulid_string}
+        _ -> :error
+      end
+    end
+  end
+
+  def dump_to_embedded(_, _), do: :error
+
   @compile {:inline, v: 1}
   defp v(?0), do: true
   defp v(?1), do: true

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule AshUlid.MixProject do
   use Mix.Project
 
   @name :ash_ulid
-  @version "1.0.0"
+  @version "1.0.1"
   @description "ULID type for Ash framework"
   @github_url "https://github.com/vonagam/ash_ulid"
 


### PR DESCRIPTION
When using `AshUlid.Type` with AshPaperTrail, attempting to create version records fails with a Jason encoding error:
```elixir
** (Jason.EncodeError) invalid byte 0x98 in <<1, 152, 160, 179, 128, 88, 205, 121, 57, 206, 221, 184, 254, 133, 7, 154>>
```

I've added dump_to_embedded/2, which AshPaperTrail calls upon types for serializing to JSON. This converts the binary UUID format to the ULID string representation so Jason can encode it properly. I've confirmed that my AshPaperTrail works properly with this new addition. 